### PR TITLE
feat(blockBinding): add note about blockBinding support to karma config

### DIFF
--- a/karma.js
+++ b/karma.js
@@ -10,6 +10,11 @@ module.exports = function(config) {
         types: true,
         annotations: true,
         sourceMap: true
+        /**
+         * Someday blockBinding would be nice, but for now it compiles to nasty
+         * ES5 code (everything in a closure)
+         */
+        // blockBinding: true
       }
     },
 


### PR DESCRIPTION
Enabling Block Binding allows use of the let keyword inside code,
which provides block-level scoping of variables without requiring a closure.

However, since we'll need to support ES5 for an indefinite period of time,
we want to make sure our code is compiling nicely to ES5. The only way to
enable use of block-scoping is to generate closures around everything in
ES5. This commit adds a commented-out block to the karma config to make it
clear why we can't yet support blockBinding.
