### PR TITLE
fix(karma): don't add debug log-level on travis, let module decide

### DIFF
--- a/karma.js
+++ b/karma.js
@@ -65,7 +65,6 @@ module.exports = function(config) {
   });
 
   if (process.env.TRAVIS) {
-    config.logLevel = config.LOG_DEBUG;
     config.sauceLabs.build = 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')';
     config.sauceLabs.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
 


### PR DESCRIPTION
The debug log-level produces some very wordy output, which is usually not very helpful.

When not intending to debug the test run, this isn't very useful, so this should be enabled at the discretion of the package being tested. It makes the watchtower.js test runs look much scarier than is really necessary.
